### PR TITLE
Adding live navigation when selecting categories

### DIFF
--- a/lib/grapevine/posts.ex
+++ b/lib/grapevine/posts.ex
@@ -15,18 +15,23 @@ defmodule Grapevine.Posts do
     |> Repo.preload([:likes, :category])
   end
 
-  def create(attrs, user_id) do
+  def create(attrs, user_id, opts) do
     attrs = Map.put(attrs, "user_id", user_id)
+    preload = Keyword.get(opts, :preload, [])
 
     %Post{}
     |> Post.changeset(attrs)
     |> Repo.insert()
+    |> maybe_preload(preload)
   end
 
-  def update(changeset, attrs) do
+  def update(changeset, attrs, opts) do
+    preload = Keyword.get(opts, :preload, [])
+
     changeset
     |> Post.changeset(attrs)
     |> Repo.update()
+    |> maybe_preload(preload)
   end
 
   def delete!(id, user_id) do
@@ -75,4 +80,14 @@ defmodule Grapevine.Posts do
   def post_changeset(_) do
     Post.changeset(%Post{}, %{})
   end
+
+  defp maybe_preload({:ok, post}, []) do
+    post
+  end
+
+  defp maybe_preload({:ok, post}, preload) do
+    Repo.preload(post, preload)
+  end
+
+  defp maybe_preload({:error, changeset}, _), do: changeset
 end

--- a/lib/grapevine/posts.ex
+++ b/lib/grapevine/posts.ex
@@ -7,7 +7,6 @@ defmodule Grapevine.Posts do
   def show_all do
     Repo.all(with_likes())
     |> Repo.preload(:category)
-
   end
 
   def get(id) do

--- a/lib/grapevine_web/live/categories_dropdown.ex
+++ b/lib/grapevine_web/live/categories_dropdown.ex
@@ -6,7 +6,7 @@ defmodule GrapevineWeb.CategoriesDropdown do
     ~L"""
     <div>
       <%= f=form_for :category_filter, "#", [phx_target: @myself, phx_change: "category_filter"] %>
-        Category: <%= select f, :category_id, Enum.map(@categories, &{&1.name, &1.id}) %>
+        Category: <%= select f, :category_id, Enum.map(@categories, &{&1.name, &1.id}), selected: @category_id %>
     </div>
     """
   end

--- a/lib/grapevine_web/live/categories_dropdown.ex
+++ b/lib/grapevine_web/live/categories_dropdown.ex
@@ -23,7 +23,6 @@ defmodule GrapevineWeb.CategoriesDropdown do
         %{"category_filter" => %{"category_id" => category_id}},
         socket
       ) do
-    Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:category_filter, category_id})
-    {:noreply, socket}
+    {:noreply, push_patch(socket, to: "/posts?category_id=#{category_id}")}
   end
 end

--- a/lib/grapevine_web/live/post_live.ex
+++ b/lib/grapevine_web/live/post_live.ex
@@ -93,7 +93,7 @@ defmodule GrapevineWeb.PostLive do
 
   def handle_info({:category_filter, "0" }, %{assigns: %{all_posts: all_posts}} = socket) do
     #push_patch(socket, to: Routes.live_path(socket, MyLive, page + 1))
-    {:noreply, assign(socket, posts: all_posts,category_id: "0",)}
+    {:noreply, assign(socket, posts: all_posts, category_id: "0")}
   end
 
   def handle_info({:category_filter, category_id}, %{assigns: %{all_posts: all_posts}} = socket) do

--- a/lib/grapevine_web/live/post_live.html.leex
+++ b/lib/grapevine_web/live/post_live.html.leex
@@ -6,7 +6,7 @@
         <% end %>
     <% end %>
 </div>
-<%= live_component GrapevineWeb.CategoriesDropdown, id: "categories_search", categories: @categories %>
+<%= live_component GrapevineWeb.CategoriesDropdown, id: "categories_search", categories: @categories, category_id: @category_id %>
 <div>
   <h2>Posts</h2>
   <table>

--- a/lib/grapevine_web/live/post_live/form_component.ex
+++ b/lib/grapevine_web/live/post_live/form_component.ex
@@ -14,14 +14,28 @@ defmodule PostLive.FormComponent do
   end
 
   def handle_event("save", %{"post" => post_params}, %{assigns: %{post: _}} = socket) do
-    post = Grapevine.Posts.update(socket.assigns.changeset, post_params)
+    post =
+      Grapevine.Posts.update(socket.assigns.changeset, post_params, preload: [:likes, :category])
+
     Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:updated_post, post})
     {:noreply, socket}
   end
 
   def handle_event("save", %{"post" => post_params}, socket) do
-    post = Grapevine.Posts.create(post_params, socket.assigns.current_user.id)
+    post =
+      Grapevine.Posts.create(post_params, socket.assigns.current_user.id,
+        preload: [:likes, :category]
+      )
+
     Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:post_created, post})
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "category_filter",
+        %{"category_filter" => %{"category_id" => _category_id}},
+        socket
+      ) do
     {:noreply, socket}
   end
 end

--- a/lib/grapevine_web/live/post_live/form_component.ex
+++ b/lib/grapevine_web/live/post_live/form_component.ex
@@ -14,13 +14,14 @@ defmodule PostLive.FormComponent do
   end
 
   def handle_event("save", %{"post" => post_params}, %{assigns: %{post: _}} = socket) do
-    Grapevine.Posts.update(socket.assigns.changeset, post_params)
-    {:noreply, push_redirect(socket, to: "/posts")}
+    post = Grapevine.Posts.update(socket.assigns.changeset, post_params)
+    Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:updated_post, post})
+    {:noreply, socket}
   end
 
   def handle_event("save", %{"post" => post_params}, socket) do
     post = Grapevine.Posts.create(post_params, socket.assigns.current_user.id)
     Phoenix.PubSub.broadcast(Grapevine.PubSub, "posts", {:post_created, post})
-    {:noreply, push_redirect(socket, to: "/posts")}
+    {:noreply, socket}
   end
 end

--- a/priv/repo/migrations/20211119001637_alter_posts_table.exs
+++ b/priv/repo/migrations/20211119001637_alter_posts_table.exs
@@ -2,13 +2,10 @@ defmodule Grapevine.Repo.Migrations.AlterPostsTable do
   use Ecto.Migration
 
   def change do
-
     drop constraint(:likes, :likes_post_id_fkey)
 
     alter table(:likes) do
       modify :post_id, references(:posts, on_delete: :delete_all)
     end
-
-
   end
 end


### PR DESCRIPTION
We used live navigation using query params to persist category id selection between refreshes.

The main idea is to store the category id in the URL and push the changes based on the category id but only send the diff for the changes through websockets instead of rendering the entire page.

Next

* Edit Post bug (how it should behave) once I submit the edit post form, then the form should disappear and the updated information should show up at the page